### PR TITLE
[必須要件]Todoの削除機能

### DIFF
--- a/api/app/controllers/todo/DeleteToDoController.scala
+++ b/api/app/controllers/todo/DeleteToDoController.scala
@@ -1,0 +1,29 @@
+package controllers.todo
+
+import cats.data.OptionT
+import lib.AsyncMessagesInjectedController
+import lib.model.ToDo
+import lib.usecase.command.DeleteToDoCommand
+import lib.usecase.command.DeleteToDoCommand.Input
+import play.api.mvc.{Action, AnyContent, Result}
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class DeleteToDoController @Inject() (
+  command: DeleteToDoCommand,
+) extends AsyncMessagesInjectedController {
+  def action(id: Long): Action[AnyContent] = Action.async { implicit request =>
+    val input = Input(ToDo.Id(id))
+
+    val optionT = for {
+      _ <- OptionT(command.run(input))
+    } yield {
+      ()
+    }
+
+    optionT.fold[Result](NotFound) { _ =>
+      Redirect(controllers.todo.routes.ViewAllTodosController.action())
+    }
+  }
+}

--- a/api/app/lib/persistence/repository/ToDoRepository.scala
+++ b/api/app/lib/persistence/repository/ToDoRepository.scala
@@ -36,4 +36,11 @@ class ToDoRepository @Inject() (
       ()
     }
   }
+
+  def delete(entity: ToDo#EmbeddedId): Future[Unit] = {
+    val query = ToDoTable.query.filter(_.id === entity.id)
+    val dbio = query.delete.map { _ => () }
+
+    master.run(dbio)
+  }
 }

--- a/api/app/lib/usecase/command/DeleteToDoCommand.scala
+++ b/api/app/lib/usecase/command/DeleteToDoCommand.scala
@@ -1,0 +1,33 @@
+package lib.usecase.command
+
+import cats.data.OptionT
+import lib.model.ToDo
+import lib.persistence.repository.ToDoRepository
+import lib.usecase.command.DeleteToDoCommand.{ Input, Output }
+
+import javax.inject.{ Inject, Singleton }
+import scala.concurrent.{ ExecutionContext, Future }
+
+@Singleton
+class DeleteToDoCommand @Inject() (
+  repository:  ToDoRepository
+)(
+  implicit ec: ExecutionContext
+) {
+  def run(input: Input): Future[Option[Output]] = {
+    val optionT =
+      for {
+        toDo <- OptionT(repository.getById(input.id))
+        _    <- OptionT.liftF(repository.delete(toDo.toEmbeddedId))
+      } yield {
+        Output()
+      }
+
+    optionT.value
+  }
+}
+
+object DeleteToDoCommand {
+  case class Input(id: ToDo.Id)
+  case class Output()
+}

--- a/api/app/lib/usecase/query/UpdateToDoErrorRecoveryPageQuery.scala
+++ b/api/app/lib/usecase/query/UpdateToDoErrorRecoveryPageQuery.scala
@@ -28,6 +28,8 @@ class UpdateToDoErrorRecoveryPageQuery @Inject()(
   }
 }
 object UpdateToDoErrorRecoveryPageQuery {
+  //TODO 頻出するクエリの共通化
+  // https://github.com/RayStarkMC/todo-app/pull/3#discussion_r1787697753
   val query = for {
     categoryTable <- ToDoCategoryTable.query
   } yield {

--- a/api/app/model/form/todo/UpdateToDoForm.scala
+++ b/api/app/model/form/todo/UpdateToDoForm.scala
@@ -8,6 +8,8 @@ case class UpdateToDoForm(title: String, body: String, category: Long, status: S
 object UpdateToDoForm {
   val form: Form[UpdateToDoForm] = Form(
     mapping(
+      //TODO 使用可能な文字の制限を追加
+      // https://github.com/RayStarkMC/todo-app/pull/3#discussion_r1787746750
       "title"    -> nonEmptyText,
       "body"     -> text,
       "category" -> longNumber(min = 1),

--- a/api/app/views/UpdateToDo.scala.html
+++ b/api/app/views/UpdateToDo.scala.html
@@ -3,12 +3,24 @@
 @import views.html.helper._
 @(vv: ViewValueUpdateToDo)(implicit request: MessagesRequestHeader)
 @views.html.common.Default(vv.vvc) {
-    @form(action = todo.routes.UpdateToDoController.action(vv.id)) {
+    @form(
+        action = todo.routes.UpdateToDoController.action(vv.id),
+        args = Symbol("id") -> "edit"
+    ) {
         @CSRF.formField
         @inputText(vv.updateToDoForm("title"))
         @textarea(vv.updateToDoForm("body"))
         @select(vv.updateToDoForm("category"), vv.categoryOptions)
         @select(vv.updateToDoForm("status"), vv.statusOptions)
-        <button type="submit">送信</button>
     }
+    @form(
+        action = todo.routes.DeleteToDoController.action(vv.id),
+        args =
+            Symbol("id") -> "delete",
+        Symbol("onSubmit") -> "return window.confirm('この操作は取り消せません。続行しますか？')"
+    ) {
+        @CSRF.formField
+    }
+    <button type="submit" form="edit">送信</button>
+    <button type="submit" form="delete">削除</button>
 }

--- a/api/conf/routes
+++ b/api/conf/routes
@@ -9,6 +9,7 @@ GET         /todo                controllers.todo.ViewAllTodosController.action(
 POST        /todo                controllers.todo.CreateToDoController.action()
 GET         /todo/update         controllers.todo.UpdateToDoPageController.action(id: Long)
 POST        /todo/update         controllers.todo.UpdateToDoController.action(id: Long)
+POST        /todo/delete         controllers.todo.DeleteToDoController.action(id: Long)
 
 # Map static resources from the /public folder to the /assets URL path
 GET         /assets/*file        controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
## 実装内容

### ToDo削除機能

正常系

- ToDo編集画面にToDo削除用のボタン設置
  - 押下で該当ToDo削除
  - ToDoは物理削除される

異常系

- ToDo削除用エンドポイントのクエリパラメーターが指定されない、または存在しないユーザーIDを指定された場合404

## 画面差分

旧

ToDo編集画面
<img width="1792" alt="スクリーンショット 2024-10-04 18 00 15" src="https://github.com/user-attachments/assets/0fa09a6a-7e7f-4c76-9aff-26134cce466e">

新

ToDo編集画面
<img width="1792" alt="スクリーンショット 2024-10-04 18 00 43" src="https://github.com/user-attachments/assets/94ae16b5-9bbc-400c-8910-1d9bea05cd90">
